### PR TITLE
Fixed header inclusion on case sensitive systems

### DIFF
--- a/RFIDuino/RFIDuino.cpp
+++ b/RFIDuino/RFIDuino.cpp
@@ -18,7 +18,7 @@
 *
 ****************************************************************************************************/
 #include "Arduino.h"
-#include "rfiduino.h"
+#include "RFIDuino.h"
 
 
 //initialize the RFIDuino object and set the pins correctlly based on hardware version


### PR DESCRIPTION
Linux, by default, uses a case sensitive filesystem.  OS X can be enabled to use a case sensitive filesystem.

If you include a file you MUST ensure that the case in the #include EXACTLY matches the case of the filesystem otherwise it will be BROKEN on anything but Windows and a default unmodified OS X installation.
